### PR TITLE
Depend on Bunny 1.5.1+

### DIFF
--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   if RUBY_PLATFORM == 'java'
     s.add_runtime_dependency 'march_hare', ['~> 2.5.1']
   else
-    s.add_runtime_dependency 'bunny', ['1.4.0']
+    s.add_runtime_dependency 'bunny', ['>= 1.5.1']
   end
 
 end


### PR DESCRIPTION
Bunny releases are almost always backwards compatible. 1.5.1 addresses the POODLE vulnerability.
