### PR TITLE
Do not delete queue on teardown

### DIFF
--- a/lib/logstash/inputs/rabbitmq/bunny.rb
+++ b/lib/logstash/inputs/rabbitmq/bunny.rb
@@ -64,7 +64,6 @@ class LogStash::Inputs::RabbitMQ
 
     def teardown
       @consumer.cancel
-      @q.delete unless @durable
 
       @ch.close   if @ch && @ch.open?
       @conn.close if @conn && @conn.open?

--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -66,7 +66,6 @@ class LogStash::Inputs::RabbitMQ
 
     def teardown
       shutdown_consumer
-      @q.delete unless @durable
 
       @ch.close         if @ch && @ch.open?
       @connection.close if @connection && @connection.open?


### PR DESCRIPTION
In none of the options "auto-delete", "durable", "passive", "exclusive" it is justifiable to delete the queue during the teardown method.

Fixes #3 
