### PR TITLE
Require March Hare using the up-to-date name

### DIFF
--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -3,7 +3,7 @@ class LogStash::Inputs::RabbitMQ
   # MarchHare-based implementation for JRuby
   module MarchHareImpl
     def register
-      require "hot_bunnies"
+      require "march_hare"
       require "java"
 
       @vhost       ||= "127.0.0.1"


### PR DESCRIPTION
The old file is gone in master.