### PR TITLE
Remove hot_bunnies.rb

### DIFF
--- a/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
+++ b/lib/logstash/inputs/rabbitmq/hot_bunnies.rb
@@ -1,1 +1,0 @@
-require "logstash/inputs/rabbitmq/march_hare"


### PR DESCRIPTION
That file has been legacy for a while. Time to remove it (its counterpart is now gone from March Hare, for example).