### PR TITLE
allow heartbeat to be configured for rabbit connections

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -45,7 +45,8 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   # Enable or disable logging
   config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
-
+  # Heartbeat delay (optional, will default to rabbitmq server config). 
+  config :heartbeat, :validate => :number
 
   #
   # Queue & Consumer

--- a/lib/logstash/inputs/rabbitmq/bunny.rb
+++ b/lib/logstash/inputs/rabbitmq/bunny.rb
@@ -30,6 +30,7 @@ class LogStash::Inputs::RabbitMQ
 
       @settings[:tls]        = @ssl if @ssl
       @settings[:verify_ssl] = @verify_ssl if @verify_ssl
+      @settings[:heartbeat] = @heartbeat
 
       proto                  = if @ssl
                                  "amqps"

--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -16,7 +16,8 @@ class LogStash::Inputs::RabbitMQ
         :host  => @host,
         :port  => @port,
         :user  => @user,
-        :automatic_recovery => false
+        :automatic_recovery => false,
+        :heartbeat_interval => @heartbeat
       }
       @settings[:pass]      = @password.value if @password
       @settings[:tls]       = @ssl if @ssl


### PR DESCRIPTION
Can pass :heartbeat into logstash rabbitmq input config to set the heartbeat delay for the rabbit connection.
Feature request #9 