### PR TITLE
Adds frame_max and timeout settings

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -45,7 +45,11 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   # Enable or disable logging
   config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
+  # Maximum permissible size of a frame (in bytes) to negotiate with clients
+  config :session_frame_max, :validate => :number, :required => false
 
+  # The default connection timeout; zero means wait indefinitely
+  config :connection_timeout, :validate => :number, :required => false
 
   #
   # Queue & Consumer

--- a/lib/logstash/inputs/rabbitmq/bunny.rb
+++ b/lib/logstash/inputs/rabbitmq/bunny.rb
@@ -15,6 +15,9 @@ class LogStash::Inputs::RabbitMQ
         :port  => @port,
         :automatically_recover => false
       }
+      @settings[:frame_max] = @session_frame_max || Bunny::Session::DEFAULT_FRAME_MAX
+      @settings[:timeout]   = @connection_timeout || Bunny::Transport::DEFAULT_CONNECTION_TIMEOUT
+      @settings[:user]      = @user || Bunny::DEFAULT_USER
       @settings[:user]      = @user || Bunny::DEFAULT_USER
       @settings[:pass]      = if @password
                                 @password.value

--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -18,6 +18,7 @@ class LogStash::Inputs::RabbitMQ
         :user  => @user,
         :automatic_recovery => false
       }
+      @settings[:timeout]   = @connection_timeout || MarchHare::ConnectionFactory::DEFAULT_CONNECTION_TIMEOUT
       @settings[:pass]      = @password.value if @password
       @settings[:tls]       = @ssl if @ssl
 


### PR DESCRIPTION
The `timeout` is available in both Bunny and March Hare. 
The `frame_max` is available in Bunny but I didn't find any reference in the March Hare code base.

Note that I could not find the `logstash-devutils` gem (on Windows) so I didn't run the tests :disappointed: 
