### PR TITLE
Include AMQP headers in events consumed from RabbitMQ.

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -46,7 +46,6 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
 
-
   #
   # Queue & Consumer
   #
@@ -81,7 +80,8 @@ class LogStash::Inputs::RabbitMQ < LogStash::Inputs::Threadable
   # Passive queue creation? Useful for checking queue existance without modifying server state
   config :passive, :validate => :boolean, :default => false
 
-
+  # Include amqp headers as k/v pairs
+  config :include_headers, :validate => :boolean, :default => false
 
   #
   # (Optional) Exchange binding

--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -112,6 +112,9 @@ class LogStash::Inputs::RabbitMQ
       @consumer = @q.build_consumer(:block => true) do |metadata, data|
         @codec.decode(data) do |event|
           decorate(event)
+	  metadata.headers.each do |header, value|
+            event[header] = value.respond_to?('toString') ? value.toString : value 
+         end if @include_headers
           @output_queue << event if event
         end
         @ch.ack(metadata.delivery_tag) if @ack


### PR DESCRIPTION
Including AMQP Header metadata was a requirement for a project I'm working on. Adding include_headers => "true" enables the functionality.