### PR TITLE
Bump march hare to 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
+* 1.1.1
+  - Bump march hare to 2.12.0 which fixes jar perms on unices
 * 1.1.0
   - Bump march hare version to 2.11.0

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '1.1.0'
+  s.version         = '1.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from a RabbitMQ exchange."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   if RUBY_PLATFORM == 'java'
     s.platform = RUBY_PLATFORM
-    s.add_runtime_dependency 'march_hare', ['~> 2.11.0']
+    s.add_runtime_dependency 'march_hare', ['~> 2.12.0']
   else
     s.add_runtime_dependency 'bunny', ['>= 1.6.0']
   end


### PR DESCRIPTION
This upgrades march hare from 2.11.0 which is a broken version (has bad unix permissions) https://github.com/elastic/logstash/issues/3781. No other changes occurred to march hare in that bump