### PR TITLE
Add metadata to MarchHare implementation

### DIFF
--- a/lib/logstash/inputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/inputs/rabbitmq/march_hare.rb
@@ -112,6 +112,12 @@ class LogStash::Inputs::RabbitMQ
       @consumer = @q.build_consumer(:block => true) do |metadata, data|
         @codec.decode(data) do |event|
           decorate(event)
+          event['@metadata']={"routingKey"     => metadata.envelope.routingKey,
+                              "deliveryTag"    => metadata.envelope.deliveryTag,
+                              "redeliver"      => metadata.envelope.redeliver,
+                              "exchange"       => metadata.envelope.exchange,
+                              "amqpTimestamp"  => Time.at(metadata.properties.timestamp.getTime/1000),
+                              "consumerTag"    => metadata.consumer_tag}
           @output_queue << event if event
         end
         @ch.ack(metadata.delivery_tag) if @ack


### PR DESCRIPTION
Solves: https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/19

Example:
"@metadata" => {
           "routingKey" => "info",
          "deliveryTag" => 2,
            "redeliver" => false,
             "exchange" => "amq.rabbitmq.log",
        "amqpTimestamp" => 2015-09-17 00:00:00 +0000,
          "consumerTag" => "amq.ctag-xxxxxxx”
    }