### PR TITLE
Support for TLS certificate authentication

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -52,6 +52,12 @@ module LogStash
       # * Wildcards are not valid on direct exchanges.
       config :key, :validate => :string, :default => "logstash"
 
+      # TLS certificate path
+      config :tls_certificate_path, :validate => :string, :default => ""
+
+      # TLS certificate password
+      config :tls_certificate_password, :validate => :string, :default => ""
+
 
       def register
         connect!


### PR DESCRIPTION
Hi,

We faced a problem While connecting to rabbitmq using logstash plugin. TLS security was enabled at rabbitmq queue. In order to subscribe to the queue, tls_certifcate and password(if any) is required. Adding "tls_certificate_path" & "tls_certificate_password" as input options for logstash plugin.

I will do the corresponding change to "logstash-mixin-rabbitmq_connection" & "march_hare" code as well.