### PR TITLE
Save message properties into @metadata fields

### DIFF
--- a/spec/inputs/rabbitmq_spec.rb
+++ b/spec/inputs/rabbitmq_spec.rb
@@ -134,7 +134,7 @@ describe "with a live server", :integration => true do
     # Extra time to make sure the consumer can attach
     # Without this there's a chance the shutdown code will execute
     # before consumption begins. This is tricky to do more elegantly
-    sleep 1
+    sleep 4
   end
 
   let(:test_connection) { MarchHare.connect(instance.send(:rabbitmq_settings)) }

--- a/spec/inputs/rabbitmq_spec.rb
+++ b/spec/inputs/rabbitmq_spec.rb
@@ -112,7 +112,7 @@ end
 
 describe "with a live server", :integration => true do
   let(:klass) { LogStash::Inputs::RabbitMQ }
-  let(:config) { {"host" => "127.0.0.1"} }
+  let(:config) { {"host" => "127.0.0.1", "auto_delete" => true } }
   let(:instance) { klass.new(config) }
   let(:hare_info) { instance.instance_variable_get(:@hare_info) }
   let(:output_queue) { Queue.new }
@@ -168,8 +168,8 @@ describe "with a live server", :integration => true do
   describe "receiving a message with a queue specified" do
     let(:config) { super.merge("queue" => queue_name) }
     let(:event) { output_queue.pop }
-    let(:queue) { test_channel.queue(queue_name) }
-    let(:queue_name) { "foo_queue" }
+    let(:queue) { test_channel.queue(queue_name, :auto_delete => true) }
+    let(:queue_name) { "logstash-input-rabbitmq-#{rand(0xFFFFFFFF)}" }
 
     context "when the message has a payload but no message headers" do
       before do
@@ -245,7 +245,6 @@ describe "with a live server", :integration => true do
   end
 
   describe LogStash::Inputs::RabbitMQ do
-    let(:config) { super.merge("queue" => "foo_queue") }
     it_behaves_like "an interruptible input plugin" do
 
     end

--- a/spec/inputs/rabbitmq_spec.rb
+++ b/spec/inputs/rabbitmq_spec.rb
@@ -166,16 +166,21 @@ describe "with a live server", :integration => true do
   end
 
   describe "receiving a message with a queue specified" do
-    let(:queue_name) { "foo_queue" }
     let(:config) { super.merge("queue" => queue_name) }
+    let(:event) { output_queue.pop }
+    let(:queue) { test_channel.queue(queue_name) }
+    let(:queue_name) { "foo_queue" }
 
-    it "should process the message" do
-      message = "Foo Message"
-      q = test_channel.queue(queue_name)
-      q.publish(message)
+    context "when the message has a payload" do
+      before do
+        queue.publish(message)
+      end
 
-      event = output_queue.pop
-      expect(event["message"]).to eql(message)
+      let(:message) { "Foo Message" }
+
+      it "should process the message and store the payload" do
+        expect(event["message"]).to eql(message)
+      end
     end
   end
 

--- a/spec/inputs/rabbitmq_spec.rb
+++ b/spec/inputs/rabbitmq_spec.rb
@@ -112,7 +112,7 @@ end
 
 describe "with a live server", :integration => true do
   let(:klass) { LogStash::Inputs::RabbitMQ }
-  let(:config) { {"host" => "127.0.0.1", "auto_delete" => true } }
+  let(:config) { {"host" => "127.0.0.1", "auto_delete" => true, "codec" => "plain" } }
   let(:instance) { klass.new(config) }
   let(:hare_info) { instance.instance_variable_get(:@hare_info) }
   let(:output_queue) { Queue.new }


### PR DESCRIPTION
Apart from the message payload itself, RabbitMQ messages contain various metadata when they're delivered to a consumer. These can include the timestamp the message was published, the name of the user that published the message, the name of the exchange/queue to which the message was published, etc.

Properties of the message and its delivery are stored in the `[@metadata][rabbitmq_properties]` field while the user-defined headers (technically a part of the properties) are stored in the `[@metadata][rabbitmq_headers]` field.

I can't for the life of me find where the preamble part of the documentation ("[Pull events from a RabbitMQ exchange. The default settings will create ...](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-rabbitmq.html)") is stored. It should be updated to include information about these new `@metadata` fields.

This PR addresses both #19 and #24.