### PR TITLE
Fix a bug here on connecting a duplicate connection would be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.5
+ - Fix a bug where when reconnecting a duplicate consumer would be created
+
 ## 3.1.4
  - Fix a bug where this plugin would not properly reconnect if it lost its connection to the server while the connection would re-establish itself, the queue subscription would not
 

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '3.1.4'
+  s.version         = '3.1.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from a RabbitMQ exchange."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This is due to https://github.com/ruby-amqp/march_hare/issues/91
Fixes https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/66

This also greatly simplifies the reconnection logic.

This was manually tested with RabbitMQ web UI. Building an integration test here would be very complicated, and really is the responsibility of March Hare