### PR TITLE
Fix regression introduced by 113ab286421756b2bc99273cc854dd4cd7130bfa…

### DIFF
--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -199,8 +199,7 @@ module LogStash
         # that we rely on MarchHare to do the reconnection for us with auto_reconnect.
         # Unfortunately, while MarchHare does the reconnection work it won't re-subscribe the consumer
         # hence the logic below.
-        @consumer = @hare_info.queue.build_consumer(:block => true,
-                                                    :on_cancellation => Proc.new { on_cancellation }) do |metadata, data|
+        @consumer = @hare_info.queue.build_consumer(:on_cancellation => Proc.new { on_cancellation }) do |metadata, data|
           @codec.decode(data) do |event|
             decorate(event)
             event["@metadata"]["rabbitmq_headers"] = get_headers(metadata)


### PR DESCRIPTION
… which reintroduced :block => true to the consumer

This error was introduced by https://github.com/logstash-plugins/logstash-input-rabbitmq/commit/113ab286421756b2bc99273cc854dd4cd7130bfa