### PR TITLE
Cleanup Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 3.3.2
+## 4.0.0
  - Ensure the consumer is done processing messages before closing channel. Fixes shutdown errors.
- - Improve performance with batch ACKs + internal queue
+ - Use an internal queue + separate thread to accelerate processing
+ - Disable metadata insertion by default, this slows things down majorly
 
 ## 3.3.1
   - New dependency requirements for logstash-core for the 5.0 release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-# 3.3.1
+## 3.3.2
+ - Ensure the consumer is done processing messages before closing channel. Fixes shutdown errors.
+ - Improve performance with batch ACKs + internal queue
+
+## 3.3.1
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 3.3.0
  - Fix a regression in 3.2.0 that reinstated behavior that duplicated consumers
  - Always declare exchanges used, the exchange now need not exist before LS starts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
  - Ensure the consumer is done processing messages before closing channel. Fixes shutdown errors.
  - Use an internal queue + separate thread to accelerate processing
  - Disable metadata insertion by default, this slows things down majorly
+ - Make exchange_type an optional config option with using 'exchange'. 
+   When used the exchange will always be declared
 
 ## 3.3.1
   - New dependency requirements for logstash-core for the 5.0 release

--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -147,10 +147,12 @@ module LogStash
       # (durable etc) must match those of the existing queue.
       config :passive, :validate => :boolean, :default => false
 
-      # The name of the exchange to bind the queue to.
+      # The name of the exchange to bind the queue to. Specify `exchange_type`
+      # as well to declare the exchange if it does not exist
       config :exchange, :validate => :string
 
-      # The type of the exchange to bind to
+      # The type of the exchange to bind to. Specifying this will cause this plugin
+      # to declare the exchange if it does not exist.
       config :exchange_type, :validate => :string
 
       # The routing key to use when binding a queue to the exchange.
@@ -190,8 +192,10 @@ module LogStash
 
       def bind_exchange!
         if @exchange
-          raise LogStash::ConfigurationError, "No exchange type declared for exchange #{exchange}!" unless @exchange_type
-          @hare_info.exchange = declare_exchange!(@hare_info.channel, @exchange, @exchange_type, @durable)
+          if @exchange_type # Only declare the exchange if @exchange_type is set!
+            @logger.info? && @logger.info("Declaring exchange '#{@exchange}' with type #{@exchange_type}")
+            @hare_info.exchange = declare_exchange!(@hare_info.channel, @exchange, @exchange_type, @durable)
+          end
           @hare_info.queue.bind(@exchange, :routing_key => @key)
         end
       end

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '3.3.2'
+  s.version         = '4.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from a RabbitMQ exchange."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 6.0.0.alpha1"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
   s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 2.3.0', '< 3.0.0'
 
   s.add_runtime_dependency 'logstash-codec-json'

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '3.3.1'
+  s.version         = '3.3.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from a RabbitMQ exchange."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/rabbitmq_spec.rb
+++ b/spec/inputs/rabbitmq_spec.rb
@@ -71,7 +71,7 @@ describe LogStash::Inputs::RabbitMQ do
       context "with an exchange declared" do
         let(:exchange) { "exchange" }
         let(:key) { "routing key" }
-        let(:rabbitmq_settings) { super.merge("exchange" => exchange, "key" => key) }
+        let(:rabbitmq_settings) { super.merge("exchange" => exchange, "key" => key, "exchange_type" => "fanout") }
 
         before do
           allow(instance).to receive(:declare_exchange!)
@@ -180,7 +180,7 @@ describe "with a live server", :integration => true do
   end
 
   describe "receiving a message with a queue + exchange specified" do
-    let(:config) { super.merge("queue" => queue_name, "exchange" => exchange_name, "exchange_type" => "fanout") }
+    let(:config) { super.merge("queue" => queue_name, "exchange" => exchange_name, "exchange_type" => "fanout", "metadata_enabled" => true) }
     let(:event) { output_queue.pop }
     let(:exchange) { test_channel.exchange(exchange_name, :type => "fanout") }
     let(:exchange_name) { "logstash-input-rabbitmq-#{rand(0xFFFFFFFF)}" }


### PR DESCRIPTION
This is a significant refactor that alters the internal design to achieve the following:

1. Fast again (actually, faster than before!) by using an internal queue and bulk ACKs. 
2. Shutdown cleanly
3. Make metadata optional (important for perf).

