### PR TITLE
Connect on run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.2.0
+  - Fix behavior where plugin would block on register if server was unavailable
+    Plugin will now always exit register successfully and just log errors on #run
+  - Bumped connection mixin dependency to better handle proxies and error logging
+
 ## 5.1.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -171,7 +171,15 @@ module LogStash
 
       def register
         @internal_queue = java.util.concurrent.ArrayBlockingQueue.new(@prefetch_count*2)
+      end
 
+      def run(output_queue)
+        setup!
+        @output_queue = output_queue
+        consume!
+      end
+
+      def setup!
         connect!
         declare_queue!
         bind_exchange!
@@ -183,11 +191,6 @@ module LogStash
                      :location => e.backtrace.first)
         sleep_for_retry
         retry
-      end
-
-      def run(output_queue)
-        @output_queue = output_queue
-        consume!
       end
 
       def bind_exchange!

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 4.1.1', '< 5.0.0'
+  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 4.2.0', '< 5.0.0'
 
   s.add_runtime_dependency 'logstash-codec-json'
 

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '5.1.1'
+  s.version         = '5.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from a RabbitMQ exchange."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Bumps our march hare version and fixes https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/91 by moving the connection to #run instead of #register 