### PR TITLE
Fix LongString bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.1
+ - Bump march_hare version to fix issue where metadata would be broken for strings > 255 chars
+   due to their transformation to rabbitmq java's LongString class
+
 ## 5.2.0
   - Fix behavior where plugin would block on register if server was unavailable
     Plugin will now always exit register successfully and just log errors on #run

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '5.2.0'
+  s.version         = '5.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from a RabbitMQ exchange."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 4.2.0', '< 5.0.0'
+  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 4.2.2', '< 5.0.0'
 
   s.add_runtime_dependency 'logstash-codec-json'
 


### PR DESCRIPTION
Bump march_hare version to fix issue where metadata would be broken for
strings > 255 char due to their transformation to rabbitmq java's LongString class

Fixes #94