### PR TITLE
Remove metadata deep traversal code, handled by MarchHare now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.2
+ - Remove legacy header normalization code. MarchHare does this directly now.
+
 ## 5.2.1
  - Bump march_hare version to fix issue where metadata would be broken for strings > 255 chars
    due to their transformation to rabbitmq java's LongString class

--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -297,37 +297,8 @@ module LogStash
       end
 
       private
-
-      # ByteArrayLongString is a private static inner class which
-      # can't be access via the regular Java::SomeNameSpace::Classname
-      # notation. See https://github.com/jruby/jruby/issues/3333.
-      ByteArrayLongString = JavaUtilities::get_proxy_class('com.rabbitmq.client.impl.LongStringHelper$ByteArrayLongString')
-
-      def get_header_value(value)
-        # Two kinds of values require exceptional treatment:
-        #
-        # String values are instances of
-        # com.rabbitmq.client.impl.LongStringHelper.ByteArrayLongString
-        # and we don't want to propagate those.
-        #
-        # List values are java.util.ArrayList objects and we need to
-        # recurse into them to convert any nested strings values.
-        if value.class == Java::JavaUtil::ArrayList
-          value.map{|item| get_header_value(item) }
-        elsif value.class == ByteArrayLongString
-          value.toString
-        else
-          value
-        end
-      end
-
-      private
       def get_headers(metadata)
-        if !metadata.headers.nil?
-          Hash[metadata.headers.map {|k, v| [k, get_header_value(v)]}]
-        else
-          {}
-        end
+	metadata.headers || {}
       end
 
       private

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '5.2.1'
+  s.version         = '5.2.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from a RabbitMQ exchange."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The code this removes is now redundant due to https://github.com/ruby-amqp/march_hare/pull/110