### PR TITLE
Undeclared exchange recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.4
+ - Fixes bug where attempting to read from undeclared exchange resulted in infinite retry loop ([#117](https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/117))
+ - Fixes bug where failing to establish initial connection resulted in a pipeline that refused to shut down ([#116](https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/116))
+
 ## 6.0.3
   - Docs: Set the default_codec doc attribute.
 

--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -196,12 +196,24 @@ module LogStash
         # re-raise the exception instead of retrying
         raise if stop?
 
+        reset!
+
         @logger.warn("Error while setting up connection for rabbitmq input! Will retry.",
                      :message  => e.message,
                      :class    => e.class.name,
                      :location => e.backtrace.first)
         sleep_for_retry
         retry
+      end
+
+      # reset a partially-established connection, enabling subsequent
+      # call to `RabbitMQ#setup!` to succeed.
+      #
+      # @api private
+      def reset!
+        @hare_info.connection && @hare_info.connection.close
+      ensure
+        @hare_info = nil
       end
 
       def bind_exchange!

--- a/lib/logstash/inputs/rabbitmq.rb
+++ b/lib/logstash/inputs/rabbitmq.rb
@@ -177,6 +177,13 @@ module LogStash
         setup!
         @output_queue = output_queue
         consume!
+      rescue => e
+        raise unless stop?
+
+        logger.warn("Ignoring exception thrown during plugin shutdown",
+                    :message  => e.message,
+                    :class    => e.class.name,
+                    :location => e.backtrace.first)
       end
 
       def setup!
@@ -185,9 +192,13 @@ module LogStash
         bind_exchange!
         @hare_info.channel.prefetch = @prefetch_count
       rescue => e
+        # when encountering an exception during shut-down,
+        # re-raise the exception instead of retrying
+        raise if stop?
+
         @logger.warn("Error while setting up connection for rabbitmq input! Will retry.",
-                     :message => e.message,
-                     :class => e.class.name,
+                     :message  => e.message,
+                     :class    => e.class.name,
                      :location => e.backtrace.first)
         sleep_for_retry
         retry

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '6.0.3'
+  s.version         = '6.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pulls events from a RabbitMQ exchange"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/rabbitmq_spec.rb
+++ b/spec/inputs/rabbitmq_spec.rb
@@ -39,6 +39,7 @@ describe LogStash::Inputs::RabbitMQ do
       allow(connection).to receive(:on_shutdown)
       allow(connection).to receive(:on_blocked)
       allow(connection).to receive(:on_unblocked)
+      allow(connection).to receive(:close)
       allow(channel).to receive(:exchange).and_return(exchange)
       allow(channel).to receive(:queue).and_return(queue)
       allow(channel).to receive(:prefetch=)


### PR DESCRIPTION
This PR introduces two changes to fix two related issues in startup

 - logstash-plugins/logstash-input-rabbitmq#116: infinite retries of initial connection should respect a plugin's stopped status, allowing pipeline to be shut down
 - logstash-plugins/logstash-input-rabbitmq#117: retries of initial connection cannot perform partial recovery, so underlying connection should be reestablished from the beginning.