### PR TITLE
update to rabbitmq-connection_mixin v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
     env: LOGSTASH_BRANCH=6.7
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=6.6
-  - rvm: jruby-1.7.27
-    env: LOGSTASH_BRANCH=5.6
   fast_finish: true
 install: true
 script: ci/build.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.0.0
+  - Require v6 version of rabbitmq-connection_mixin which removed obsolete options, hence the major bump.
+  - Updated march_hare dependency to 4.x via rabbitmq-connection_mixin 6.1.0
+  - Fixed issue with custom port assignment when multiple hosts are specified via rabbitmq-connection_mixin 6.1.1
+
 ## 6.0.3
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -233,7 +233,13 @@ i.e.
 or
   host => ["host01", "host02]
 
-if multiple hosts are provided on the initial connection and any subsequent
+A host can also include a port
+i.e.
+host => ["host01:123", "host02:234]
+
+Note that if a host does not include a port, the `port` option will be applied.
+
+If multiple hosts are provided on the initial connection and any subsequent
 recovery attempts of the hosts is chosen at random and connected to.
 Note that only one host connection is active at a time.
 
@@ -283,7 +289,8 @@ RabbitMQ password
   * Value type is <<number,number>>
   * Default value is `5672`
 
-RabbitMQ port to connect on
+RabbitMQ port to connect on.
+This port number will be applied to hosts of the `host` option without an explicit port.
 
 [id="plugins-{type}s-{plugin}-prefetch_count"]
 ===== `prefetch_count` 

--- a/logstash-input-rabbitmq.gemspec
+++ b/logstash-input-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-rabbitmq'
-  s.version         = '6.0.3'
+  s.version         = '7.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pulls events from a RabbitMQ exchange"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 5.0.0', '< 6.0.0'
+  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 6.0.0', '< 7.0.0'
 
   s.add_runtime_dependency 'logstash-codec-json'
 

--- a/spec/inputs/rabbitmq_spec.rb
+++ b/spec/inputs/rabbitmq_spec.rb
@@ -49,7 +49,7 @@ describe LogStash::Inputs::RabbitMQ do
     end
 
     it "should default the codec to JSON" do
-      expect(instance.codec).to be_a(LogStash::Codecs::JSON)
+      expect(instance.codec.config_name).to eq("json")
     end
 
     describe "#connect!" do


### PR DESCRIPTION
- Bump major to v7.0.0 to update `rabbitmq-connection_mixin` to v6 (currently 6.1.1)
- Update documentation
