### PR TITLE
Update documentation: Port parameter is not used. Port must be placed inside of Host parameter

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -97,7 +97,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-metadata_enabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-passive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
-| <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-prefetch_count>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-queue>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
@@ -224,6 +223,7 @@ Heartbeat delay in seconds. If unspecified no heartbeats will be sent
   * This is a required setting.
   * Value type is <<string,string>>
   * There is no default value for this setting.
+  * Optional: Add port number at the end. Default port is `5672`
 
 Common functionality for the rabbitmq input/output
 RabbitMQ server address(es)
@@ -232,6 +232,10 @@ i.e.
   host => "localhost"
 or
   host => ["host01", "host02]
+  
+Connecting to a specific port, add the port followed by a colon.
+
+i.e. host => "localhost:33445"
 
 if multiple hosts are provided on the initial connection and any subsequent
 recovery attempts of the hosts is chosen at random and connected to.
@@ -276,14 +280,6 @@ a queue that already exists, the queue options for this plugin
   * Default value is `"guest"`
 
 RabbitMQ password
-
-[id="plugins-{type}s-{plugin}-port"]
-===== `port` 
-
-  * Value type is <<number,number>>
-  * Default value is `5672`
-
-RabbitMQ port to connect on
 
 [id="plugins-{type}s-{plugin}-prefetch_count"]
 ===== `prefetch_count` 


### PR DESCRIPTION
Removed port as separate config parameter and added the port documentation at the host parameter documentation.

I am using version of input plugin 6.0.3 under windows and specifying port as separate port parameter was not working at all and it took some time to figure out that just the documentation is wrong and the port has to be specified inside the host parameter.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
