### PR TITLE
point users+contributors to integration source

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,11 @@
-Please post all product and debugging questions on our [forum](https://discuss.elastic.co/c/logstash). Your questions will reach our wider community members there, and if we confirm that there is a bug, then we can open a new issue here.
+## RabbitMQ Input Plugin's Issue Tracker Has Moved
 
-For all general issues, please provide the following details for fast resolution:
+This RabbitMQ Input Plugin is now a part of the [RabbitMQ Integration Plugin][integration-source];
+this project remains open for backports of fixes from that project to the 6.x series where possible, but issues should first be filed on the [integration plugin][integration-issues].
 
-- Version:
-- Operating System:
-- Config File (if you have sensitive info, please remove it):
-- Sample Data:
-- Steps to Reproduce:
+Please post all product and debugging questions on our [forum][logstash-forum].
+Your questions will reach our wider community members there, and if we confirm that there is a bug, then we can open a new issue on the appropriate project.
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-rabbitmq
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-rabbitmq/issues/
+[logstash-forum]: https://discuss.elastic.co/c/logstash

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,14 @@
+## RabbitMQ Input Plugin's Source Has Moved
+
+This RabbitMQ Input Plugin is now a part of the [RabbitMQ Integration Plugin][integration-source];
+this project remains open for backports of fixes from that project to the 6.x series where possible, but pull-requests should first be made on the [integration plugin][integration-pull-requests].
+
+If you have already made commits on a clone of this stand-alone repository, it's ok! Go ahead and open the Pull Request here, and open an Issue linking to it on the [integration plugin][integration-issues] -- we'll work with you to sort it all out and to get the backport applied.
+
+## Contributor Agreement
+
 Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-rabbitmq
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-rabbitmq/issues/
+[integration-pull-requests]: https://github.com/logstash-plugins/logstash-integration-rabbitmq/pulls

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ This is a plugin for [Logstash](https://github.com/elastic/logstash).
 
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
 
+
+## RabbitMQ Input Plugin Has Moved
+
+This RabbitMQ Input Plugin is now a part of the [RabbitMQ Integration Plugin][integration-source];
+this project remains open for backports of fixes from that project to the 6.x series where possible, but issues should first be filed on the [integration plugin][integration-issues].
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-rabbitmq
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-rabbitmq/issues/
+
 ## Documentation
 
 Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,6 +2,16 @@
 :type: input
 :default_codec: json
 
+/////////////////////////////////////////////
+// RabbitMQ Input Plugin Source Has Moved  //
+// --------------------------------------- //
+// The RabbitMQ Input Plugin is now a part //
+// of the RabbitMQ Integration.            //
+//                                         //
+// This stand-alone plugin project remains //
+// open for backports to the 6.x series.   //
+/////////////////////////////////////////////
+
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////


### PR DESCRIPTION
Since the forward-moving source of this plugin is now a part of the
RabbitMQ Integration, provide users and contributors simple paths forward
for reporting issues and contributing patches.

***

This change is likely to be the prototype for at least the next several integration plugin projects, so I'm hoping for a little extra scrutiny.

The goal is to redirect users and contributors to the integration project as early as possible, and to provide support for moving forward with reporting issues or contributing fixes if they mistakenly end up here.

 - `README.md`: add a clear block at the top, pointing toward the integration project and defining the purpose of this stand-alone project still being open.
 - `docs/index.asciidoc`: since this file has been moved to `docs/${type}-${name}.asciidoc` in the integration project (which contains its own `docs/index.asciidoc`), a user attempting to contribute changes from the stand-alone project to this file is going to create a patch that doesn't apply cleanly. This header is meant to get them looking in the right direction _before_ putting in work that will be tedious to resolve.
- `.github/ISSUE_TEMPLATE.md`: when a user encounters this, typically they are in the process of opening an issue on the project (and likely already frustrated). By pointing them to the integration project and reiterating the purpose of the stand-alone project being open for backports, I hope to alleviate some pain.
- `.github/PULL_REQUEST_TEMPLATE.md`: when a contributor encounters this, typically they have missed all of the other signs and invested significant effort into putting together their proposed changes. My goal with this document is to point them in the right direction _and_ offer assurance of help moving forward to reduce their frustration.

***

_Note: even though the integration plugin contains the complete source history of this plugin and will be our Source of Truth moving forward, we are _not_ closing the issue tracker here, nor do we plan to archive this stand-alone repository in the immediate future. Individual plugins cannot presently be built from the integrated source, so 6.x maintenance will live on here._