### PR TITLE
tip on avoiding a common configuration error with this setting

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -197,6 +197,8 @@ The default connection timeout in milliseconds. If not specified the timeout is 
   * Default value is `false`
 
 Is this queue durable? (aka; Should it survive a broker restart?)
+If consuming directly from a queue you must set this value to match the existing queue setting,
+otherwise the connection will fail due to an inequivalent arg error.
 
 [id="plugins-{type}s-{plugin}-exchange"]
 ===== `exchange`


### PR DESCRIPTION
Default rabbitmq durability is true, default Logstash durability is false.
If consuming directly from a queue then it's likely users will hit these mismatched defaults.
